### PR TITLE
fix invalid printf formats

### DIFF
--- a/lib/text_graph.ml
+++ b/lib/text_graph.ml
@@ -26,8 +26,8 @@ let line ~label ~value ~norm =
   assert (0 <= percentage && percentage <= 100);
   let pre =
     if norm > 1.0
-    then sprintf "%.10s %5.2f " label value
-    else sprintf "%.10s %8.0f " label value
+    then sprintf "%10s %5.2f " label value
+    else sprintf "%10s %8.0f " label value
   in
   pre ^ data_line percentage
 


### PR DESCRIPTION
There are some format strings that are "invalid" in the textutils sources.

In general, invalid formats are nonsensical format strings that were accepted in OCaml 4.01.0 and earlier, but whose semantics is unspecified. They are still accepted by the new Printf implementation of OCaml 4.02.0 but in some cases with different semantics, and they will be statically rejected by OCaml 4.03.0.

You can check for them in OCaml 4.02.0 with the flag -strict-formats.

In the case of textutils, it has formats of the form "%.10s", which does not make sense (it would mean to print a string with 10 digits after the decimal point). In 4.01.0, it pads the string on the right, while in 4.02.0 it does no padding. In 4.02.1, it will pad on the right for compatibility with 4.01.0, but you should still take the opportunity to review the code and fix the format. The patch changes it to "%10s", which recovers the previous behaviour, but that might still be wrong.
